### PR TITLE
Fixed a typo in samba vars

### DIFF
--- a/samba/tasks/main.yml
+++ b/samba/tasks/main.yml
@@ -18,12 +18,12 @@
  - name: Add the User(s) to Samba group
    user: name={{ item.name }} groups={{ samba_group_name }} append=yes
    with_items:
-     smaba_users
+     samba_users
 
  - name: Create Samba Password for User(s)
    shell: (echo {{ item.smbpasswd }}; echo {{ item.smbpasswd }}) | smbpasswd -s -a {{ item.name }}
    with_items:
-     smaba_users
+     samba_users
 
  - name: Check that {{ public_share_path }} exist
    command: /usr/bin/test -e {{ public_share_path }}

--- a/samba/vars/main.yml
+++ b/samba/vars/main.yml
@@ -5,6 +5,6 @@
  private_share_name: private
  private_share_path: /samba/private
  samba_group_name: smbgrp
- smaba_users:
+ samba_users:
    - { name: 'arbab', smbpasswd: 'pass123' }
    - { name: 'hussain', smbpasswd: 'password' }


### PR DESCRIPTION
There was a typo in the samba role in vars/main.yml
